### PR TITLE
Support for numerical values and graphing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 gin-bin
 mondash
+
+*.sh

--- a/main.go
+++ b/main.go
@@ -30,7 +30,7 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
-	s3Conn := s3.New(awsAuth, aws.EUWest)
+	s3Conn := s3.New(awsAuth, aws.USEast)
 	s3Storage = s3Conn.Bucket(os.Getenv("S3Bucket"))
 
 	m := martini.Classic()

--- a/main.go
+++ b/main.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
+	//"os"
 	"time"
 
-	"log"
+	//"log"
 
-	"launchpad.net/goamz/aws"
-	"launchpad.net/goamz/s3"
+	//"launchpad.net/goamz/aws"
+	//"launchpad.net/goamz/s3"
 
 	"github.com/flosch/pongo2"
 	"github.com/go-martini/martini"
@@ -20,18 +20,19 @@ import (
 )
 
 var templates = make(map[string]*pongo2.Template)
-var s3Storage *s3.Bucket
+
+//var s3Storage *s3.Bucket
 
 func main() {
 	preloadTemplates()
 
 	// Initialize S3 storage
-	awsAuth, err := aws.EnvAuth()
-	if err != nil {
-		log.Fatal(err)
-	}
-	s3Conn := s3.New(awsAuth, aws.USEast)
-	s3Storage = s3Conn.Bucket(os.Getenv("S3Bucket"))
+	//awsAuth, err := aws.EnvAuth()
+	//if err != nil {
+	//	log.Fatal(err)
+	//}
+	//s3Conn := s3.New(awsAuth, aws.USEast)
+	//s3Storage = s3Conn.Bucket(os.Getenv("S3Bucket"))
 
 	m := martini.Classic()
 

--- a/structs.go
+++ b/structs.go
@@ -3,8 +3,10 @@ package main
 import (
 	"encoding/json"
 	"errors"
-	"launchpad.net/goamz/s3"
+	"io/ioutil"
+	//"launchpad.net/goamz/s3"
 	"log"
+	//"os"
 	"sort"
 	"strconv"
 	"time"
@@ -17,7 +19,7 @@ type dashboard struct {
 }
 
 func loadDashboard(dashid string) (*dashboard, error) {
-	data, err := s3Storage.Get(dashid)
+	data, err := ioutil.ReadFile(dashid + ".txt")
 	if err != nil {
 		return &dashboard{}, errors.New("Dashboard not found")
 	}
@@ -34,7 +36,8 @@ func (d *dashboard) Save() {
 		log.Printf("Error while marshalling dashboard: %s", err)
 		return
 	}
-	err = s3Storage.Put(d.DashboardID, data, "application/json", s3.Private)
+	err = ioutil.WriteFile(d.DashboardID+".txt", data, 0600)
+
 	if err != nil {
 		log.Printf("Error while storing dashboard: %s", err)
 	}

--- a/structs.go
+++ b/structs.go
@@ -120,11 +120,11 @@ func (dm *dashboardMetric) Update(m *dashboardMetric) {
 	if m.Freshness != 0 {
 		dm.Freshness = m.Freshness
 	}
-	dm.HistoricalData = append(dashboardMetricHistory{dashboardMetricStatus{
+	dm.HistoricalData = append(dm.HistoricalData, dashboardMetricStatus{
 		Time:   time.Now(),
 		Status: m.Status,
 		Value:  m.Value,
-	}}, dm.HistoricalData...)
+	})
 
 	countStatus := make(map[string]float64)
 

--- a/structs.go
+++ b/structs.go
@@ -89,10 +89,17 @@ func newDashboardMetric() *dashboardMetric {
 func median(values []float64) float64 {
 	sort.Float64s(values)
 
+	if len(values) == 1 {
+		return values[0]
+	}
+
 	// If even, take an average
 	if len(values)%2 == 0 {
 		return 0.5*values[len(values)/2] + 0.5*values[len(values)/2-1]
 	}
+
+	log.Printf("len(values)=%v, len(values)/2=%v\n", len(values), len(values)/2)
+
 	return values[len(values)/2-1]
 }
 

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -13,6 +13,20 @@
 	<!-- Chartist Library -->
 	<link rel="stylesheet" href="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.css">
     <script src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
+	<script>
+	function timeConverter(UNIX_timestamp){
+	  var a = new Date(UNIX_timestamp*1000);
+	  var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+	  var year = a.getFullYear();
+	  var month = months[a.getMonth()];
+	  var date = a.getDate();
+	  var hour = a.getHours();
+	  var min = a.getMinutes();
+	  var sec = a.getSeconds();
+	  var time = date + ' ' + month + ' ' + year + ' ' + hour + ':' + min + ':' + sec ;
+	  return time;
+	}
+	</script>
 
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
@@ -90,6 +104,10 @@
 				            {{ metric.DataHistory }}
 				        ]
 				    };
+				
+					for (var i = 0; i < data.labels.length; i++) {
+						data.labels[i] = timeConverter(data.labels[i]);
+					}
 				
 				    new Chartist.Line('.{{metric.MetricID}}', data);
 			</script>

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -81,11 +81,11 @@
       </div>
     {% else %}
       {% for metric in metrics %}
-        {% if metric.Status == "OK" %}
+        {% if metric.StatisticalStatus == "OK" %}
         <div class="row alert alert-success">
-        {% elif metric.Status == "Warning" %}
+        {% elif metric.StatisticalStatus == "Warning" %}
         <div class="row alert alert-warning">
-        {% elif metric.Status == "Critical" %}
+        {% elif metric.StatisticalStatus == "Critical" %}
         <div class="row alert alert-danger">
         {% else %}
         <div class="row alert alert-info">
@@ -93,7 +93,7 @@
           <div class="col-md-9">
             <h4>{{ metric.Title }}</h4>
             <p>{{ metric.Description }}</p>
-			<span class="label label-info">Current Value: {{ metric.Value }}</span>
+			<span><span class="label label-info">Current Value: {{ metric.Value }}</span> {{ metric.MadMultiplier }} MAD above the Median ({{ metric.Median }})</span>
 			<div class="ct-chart {{metric.MetricID}} .ct-double-octave"></div>
 			<script>
 				    var data = {

--- a/templates/dashboard.html
+++ b/templates/dashboard.html
@@ -10,6 +10,10 @@
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap.min.css">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.2/css/bootstrap-theme.min.css">
 
+	<!-- Chartist Library -->
+	<link rel="stylesheet" href="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.css">
+    <script src="//cdn.jsdelivr.net/chartist.js/latest/chartist.min.js"></script>
+
     <!-- HTML5 shim and Respond.js for IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
@@ -75,6 +79,20 @@
           <div class="col-md-9">
             <h4>{{ metric.Title }}</h4>
             <p>{{ metric.Description }}</p>
+			<span class="label label-info">Current Value: {{ metric.Value }}</span>
+			<div class="ct-chart {{metric.MetricID}} .ct-double-octave"></div>
+			<script>
+				    var data = {
+				        // A labels array that can contain any sort of values
+				        labels: {{ metric.LabelHistory }},
+				        // Our series array that contains series objects or in this case series data arrays
+				        series: [
+				            {{ metric.DataHistory }}
+				        ]
+				    };
+				
+				    new Chartist.Line('.{{metric.MetricID}}', data);
+			</script>
             <small>
               Updated {{ metric.Meta.LastUpdate|naturaltime}}
               {% if metric.Status != "OK" %}

--- a/web_handlers.go
+++ b/web_handlers.go
@@ -19,10 +19,10 @@ func handleRedirectWelcome(res http.ResponseWriter, req *http.Request) {
 
 func handleCreateRandomDashboard(res http.ResponseWriter, req *http.Request) {
 	urlProposal := generateAPIKey()[0:20]
-	_, err := s3Storage.Get(urlProposal)
+	_, err := ioutil.ReadFile(urlProposal + ".txt")
 	for err == nil {
 		urlProposal = generateAPIKey()[0:20]
-		_, err = s3Storage.Get(urlProposal)
+		_, err = ioutil.ReadFile(urlProposal + ".txt")
 	}
 	http.Redirect(res, req, fmt.Sprintf("/%s", urlProposal), http.StatusTemporaryRedirect)
 }
@@ -62,7 +62,7 @@ func handleDeleteDashboard(params martini.Params, req *http.Request, res http.Re
 		return
 	}
 
-	_ = s3Storage.Del(params["dashid"])
+	//_ = s3Storage.Del(params["dashid"])
 	http.Error(res, "OK", http.StatusOK)
 }
 


### PR DESCRIPTION
I've added support for submitting numerical values and graphing them using Chartist.js

The way I've written this, the color of the box is dependent on the calculated values. If it significantly deviates from the median, the color changes. However, the progress bar uses your logic of the history of status that's submitted.

Before accepting this pull request, beware that I had to change the aws region to USEast to work with my bucket. Before incorporating the changes, perhaps it might be best to read the region as an environment variable.

![screen shot 2015-02-22 at 9 55 15 pm](https://cloud.githubusercontent.com/assets/7146154/6322208/99070d4c-badd-11e4-8859-27b3899986b4.png)
